### PR TITLE
Add python==3.9 dependency

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,7 +31,7 @@ on your machine, and execute the commands below::
     $ conda config --add channels defaults
     $ conda config --add channels bioconda
     $ conda config --add channels conda-forge
-    $ mamba create -n runHiC matplotlib biopython pairtools cooler sra-tools bwa minimap2 samtools pigz chromap
+    $ mamba create -n runHiC "python==3.9" matplotlib biopython pairtools cooler sra-tools bwa minimap2 samtools pigz chromap
     $ mamba activate runHiC
 
 Install runHiC


### PR DESCRIPTION
"pairtools==0.3" requires Python version >=3.6 and <=3.9. It fails to install with the current 3.11 version. Explicitly specifying "python==3.9" allowed the installation. Btw, http://xiaotaowang.github.io/HiC_pipeline/index.html is not functioning, I believe, that should be tweaked somewhere in the settings.

The error was:
```
Could not solve for environment specs
The following packages are incompatible
└─ pairtools 0.3  is installable with the potential options
   ├─ pairtools 0.3.0 would require
   │  └─ python >=3.6,<3.7.0a0 , which can be installed;
   ├─ pairtools 0.3.0 would require
   │  └─ python >=3.7,<3.8.0a0 , which can be installed;
   ├─ pairtools 0.3.0 would require
   │  └─ python >=3.8,<3.9.0a0 , which can be installed;
   └─ pairtools 0.3.0 would require
      └─ python >=3.9,<3.10.0a0 , which can be installed.
```